### PR TITLE
feat(gateway): add get_tool_schema MCP tool

### DIFF
--- a/src/nexus_dev/gateway/__init__.py
+++ b/src/nexus_dev/gateway/__init__.py
@@ -1,0 +1,5 @@
+"""Gateway module for MCP connection management."""
+
+from .connection_manager import ConnectionManager, MCPConnection
+
+__all__ = ["ConnectionManager", "MCPConnection"]


### PR DESCRIPTION
## Overview

This PR implements the `get_tool_schema` MCP tool as described in Issue #18. This is a key component of **Phase 3 (Gateway Mode)** for MCP tool management.

## Changes

### New Files
- **`src/nexus_dev/gateway/__init__.py`**: Module initialization to properly export `ConnectionManager` and `MCPConnection` classes

### Modified Files
- **`src/nexus_dev/server.py`**:
  - Added import for `ConnectionManager` from gateway module
  - Added global `_connection_manager` singleton state
  - Added `_get_connection_manager()` helper function
  - Implemented `get_tool_schema(server, tool)` MCP tool

- **`tests/unit/test_server.py`**:
  - Added `TestGetToolSchema` test class with 6 comprehensive tests

## Implementation Details

The `get_tool_schema` tool:
1. Validates MCP configuration exists
2. Checks if the requested server exists and is enabled
3. Uses the `ConnectionManager` to establish/reuse connections to MCP servers
4. Fetches the tool list and returns the full JSON schema for the specified tool
5. Provides helpful error messages including available servers/tools

### API

```python
@mcp.tool()
async def get_tool_schema(server: str, tool: str) -> str:
    """Get the full JSON schema for a specific MCP tool.

    Args:
        server: Server name (e.g., "github")
        tool: Tool name (e.g., "create_pull_request")

    Returns:
        Full JSON schema with parameter types and descriptions.
    """
```

### Example Output

```json
{
  "server": "github",
  "tool": "create_issue",
  "description": "Create a GitHub issue",
  "parameters": {
    "type": "object",
    "properties": {
      "owner": {"type": "string"},
      "repo": {"type": "string"},
      "title": {"type": "string"}
    }
  }
}
```

## Testing

All 262 tests pass, including 6 new tests for `get_tool_schema`:
- ✅ `test_get_tool_schema_no_config` - Returns message when no MCP config
- ✅ `test_get_tool_schema_server_not_found` - Returns error for missing server
- ✅ `test_get_tool_schema_server_disabled` - Returns error for disabled server 
- ✅ `test_get_tool_schema_success` - Returns valid JSON schema
- ✅ `test_get_tool_schema_tool_not_found` - Returns error for missing tool
- ✅ `test_get_tool_schema_connection_error` - Handles connection errors gracefully

## Checklist

- [x] Returns full JSON schema
- [x] Connects to server to fetch fresh schema
- [x] Error handling for missing server/tool
- [x] Tests
- [x] `make check` passes (lint + format + type-check)
- [x] `make test` passes (262 tests)

## Dependencies

- Depends on #16 (Connection Manager) ✅ Already implemented

Closes #18