### PR TITLE
feat: Add invoke_tool MCP tool for gateway mode

### DIFF
--- a/src/nexus_dev/gateway/connection_manager.py
+++ b/src/nexus_dev/gateway/connection_manager.py
@@ -90,3 +90,20 @@ class ConnectionManager:
             if coros:
                 await asyncio.gather(*coros, return_exceptions=True)
             self._connections.clear()
+
+    async def invoke_tool(
+        self, name: str, config: MCPServerConfig, tool: str, arguments: dict[str, Any]
+    ) -> Any:
+        """Invoke a tool on a backend MCP server.
+
+        Args:
+            name: Server name for connection pooling.
+            config: Server configuration.
+            tool: Tool name to invoke.
+            arguments: Tool arguments.
+
+        Returns:
+            Tool execution result (MCP CallToolResult).
+        """
+        session = await self.get_connection(name, config)
+        return await session.call_tool(tool, arguments)

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -95,3 +95,22 @@ async def test_connection_manager_disconnect_all(mock_config):
     assert mock_conn1.disconnect.called
     assert mock_conn2.disconnect.called
     assert len(manager._connections) == 0
+
+
+@patch("nexus_dev.gateway.connection_manager.MCPConnection")
+@pytest.mark.asyncio
+async def test_connection_manager_invoke_tool(mock_conn_cls, mock_config):
+    """Test invoke_tool uses connection and calls tool."""
+    manager = ConnectionManager()
+
+    mock_session = AsyncMock()
+    mock_session.call_tool = AsyncMock(return_value="result")
+
+    mock_conn_instance = AsyncMock()
+    mock_conn_instance.connect.return_value = mock_session
+    mock_conn_cls.return_value = mock_conn_instance
+
+    result = await manager.invoke_tool("test", mock_config, "my_tool", {"arg": "value"})
+
+    assert result == "result"
+    mock_session.call_tool.assert_called_once_with("my_tool", {"arg": "value"})


### PR DESCRIPTION
## Summary

This PR implements the `invoke_tool` MCP tool - the **core gateway functionality** for Phase 3 of the MCP tool management plan. This enables AI agents to invoke tools on backend MCP servers through Nexus-Dev as a central gateway.

Closes #19

## Changes

### Gateway Layer - ConnectionManager
- Added `invoke_tool` method to `ConnectionManager` class in `src/nexus_dev/gateway/connection_manager.py`
- Leverages existing connection pooling and lifecycle management
- Calls `session.call_tool()` on the connected MCP server

### Server Layer - MCP Tool
- Added `invoke_tool` MCP tool in `src/nexus_dev/server.py`
- Added `Any` type import from `typing` module
- Full validation: checks server exists, is enabled, handles errors gracefully
- Formats MCP `CallToolResult` content for AI consumption (text and non-text content)

### Unit Tests
Added 9 comprehensive unit tests covering:
- No config scenario
- Server not found
- Server disabled
- Success with text content
- Success with no arguments (passes empty dict)
- Connection error handling
- Multiple content items
- Non-text content items
- ConnectionManager.invoke_tool method

## Workflow Example

After this implementation, the complete gateway flow works as follows:

```mermaid
sequenceDiagram
    participant AI as AI Agent
    participant Nexus as Nexus-Dev
    participant GitHub as GitHub MCP

    AI->>Nexus: search_tools("create GitHub issue")
    Nexus-->>AI: github.create_issue
    AI->>Nexus: get_tool_schema("github", "create_issue")
    Nexus-->>AI: Full parameter schema
    AI->>Nexus: invoke_tool("github", "create_issue", {...})
    Nexus->>GitHub: call_tool("create_issue", {...})
    GitHub-->>Nexus: CallToolResult
    Nexus-->>AI: "Issue created: #123"
```

## Testing

All checks pass:
- ✅ Linting (`ruff check`)
- ✅ Formatting (`ruff format`)
- ✅ Type checking (`mypy`)
- ✅ 281 unit tests passing

```bash
make check  # All pass
make test   # 281 passed, 1 warning
```

## Acceptance Criteria (from Issue #19)
- [x] Can invoke tools on configured servers
- [x] Validates server exists and is enabled
- [x] Passes arguments correctly
- [x] Formats result for AI consumption
- [x] Error handling with helpful messages
- [x] Tests with mocked connection manager

## Dependencies
- ✅ Issue #16 - ConnectionManager (already implemented)
- ✅ Issue #17 - list_servers (already implemented)
- ✅ Issue #18 - get_tool_schema (already implemented)
