### PR TITLE
feat: Add error handling and reconnection logic for MCP connections

### DIFF
--- a/src/nexus_dev/gateway/__init__.py
+++ b/src/nexus_dev/gateway/__init__.py
@@ -1,5 +1,10 @@
 """Gateway module for MCP connection management."""
 
-from .connection_manager import ConnectionManager, MCPConnection
+from .connection_manager import (
+    ConnectionManager,
+    MCPConnection,
+    MCPConnectionError,
+    MCPTimeoutError,
+)
 
-__all__ = ["ConnectionManager", "MCPConnection"]
+__all__ = ["ConnectionManager", "MCPConnection", "MCPConnectionError", "MCPTimeoutError"]

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp import ClientSession
 
-from nexus_dev.gateway.connection_manager import ConnectionManager, MCPConnection
+from nexus_dev.gateway.connection_manager import (
+    ConnectionManager,
+    MCPConnection,
+    MCPConnectionError,
+    MCPTimeoutError,
+)
 from nexus_dev.mcp_config import MCPServerConfig
 
 
@@ -21,96 +28,320 @@ def mock_config():
     )
 
 
-@patch("nexus_dev.gateway.connection_manager.stdio_client")
-@patch("nexus_dev.gateway.connection_manager.ClientSession")
-@pytest.mark.asyncio
-async def test_mcp_connection_lifecycle(mock_session_cls, mock_stdio, mock_config):
-    """Test connection establishment and teardown."""
-    # Mock context managers
-    mock_transport_cm = AsyncMock()
-    mock_stdio.return_value = mock_transport_cm
-    mock_transport_cm.__aenter__.return_value = (MagicMock(), MagicMock())
+class TestMCPConnectionLifecycle:
+    """Tests for MCPConnection connect/disconnect lifecycle."""
 
-    mock_session_cm = AsyncMock()
-    mock_session_cls.return_value = mock_session_cm
-    mock_session = AsyncMock(spec=ClientSession)
-    mock_session_cm.__aenter__.return_value = mock_session
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @patch("nexus_dev.gateway.connection_manager.ClientSession")
+    @pytest.mark.asyncio
+    async def test_connection_lifecycle(self, mock_session_cls, mock_stdio, mock_config):
+        """Test connection establishment and teardown."""
+        # Mock context managers
+        mock_transport_cm = AsyncMock()
+        mock_stdio.return_value = mock_transport_cm
+        mock_transport_cm.__aenter__.return_value = (MagicMock(), MagicMock())
 
-    conn = MCPConnection(name="test", config=mock_config)
+        mock_session_cm = AsyncMock()
+        mock_session_cls.return_value = mock_session_cm
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session_cm.__aenter__.return_value = mock_session
 
-    # Test connect
-    session = await conn.connect()
+        conn = MCPConnection(name="test", config=mock_config)
 
-    assert session == mock_session
-    assert mock_transport_cm.__aenter__.called
-    assert mock_session_cm.__aenter__.called
-    assert mock_session.initialize.called
+        # Test connect
+        session = await conn.connect()
 
-    # Test disconnect
-    await conn.disconnect()
+        assert session == mock_session
+        assert mock_transport_cm.__aenter__.called
+        assert mock_session_cm.__aenter__.called
+        assert mock_session.initialize.called
 
-    assert mock_session_cm.__aexit__.called
-    assert mock_transport_cm.__aexit__.called
-    assert conn.session is None
+        # Test disconnect
+        await conn.disconnect()
 
-
-@patch("nexus_dev.gateway.connection_manager.MCPConnection")
-@pytest.mark.asyncio
-async def test_connection_manager_reuse(mock_conn_cls, mock_config):
-    """Test connection reuse."""
-    manager = ConnectionManager()
-    mock_conn_instance = AsyncMock()
-    mock_conn_instance.connect.return_value = AsyncMock(spec=ClientSession)
-    mock_conn_cls.return_value = mock_conn_instance
-
-    # First call - creates new connection
-    s1 = await manager.get_connection("s1", mock_config)
-    assert mock_conn_cls.call_count == 1
-
-    # Second call - reuses connection
-    s2 = await manager.get_connection("s1", mock_config)
-    assert mock_conn_cls.call_count == 1
-    assert s1 == s2
+        assert mock_session_cm.__aexit__.called
+        assert mock_transport_cm.__aexit__.called
+        assert conn.session is None
 
 
-@pytest.mark.asyncio
-async def test_connection_manager_disconnect_all(mock_config):
-    """Test disconnecting all servers."""
-    manager = ConnectionManager()
+class TestMCPConnectionPing:
+    """Tests for connection health check via ping."""
 
-    # We'll use real MCPConnection mocked partially to verify disconnect logic
-    # But it's easier to mock internal _connections dict if we want to verify calls
-    # Let's just mock the connection objects stored in the manager.
+    @pytest.mark.asyncio
+    async def test_ping_healthy_session_reused(self, mock_config):
+        """Test that healthy session is reused after ping."""
+        conn = MCPConnection(name="test", config=mock_config)
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.send_ping = AsyncMock()
+        conn.session = mock_session
 
-    mock_conn1 = AsyncMock()
-    mock_conn2 = AsyncMock()
+        # Connect should return existing session after successful ping
+        result = await conn.connect()
 
-    # Manually inject mocks into manager to test disconnect logic
-    # Note: accessing private member for testing purposes
-    manager._connections["c1"] = mock_conn1
-    manager._connections["c2"] = mock_conn2
+        assert result == mock_session
+        mock_session.send_ping.assert_called_once()
 
-    await manager.disconnect_all()
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @patch("nexus_dev.gateway.connection_manager.ClientSession")
+    @pytest.mark.asyncio
+    async def test_ping_lost_connection_reconnects(self, mock_session_cls, mock_stdio, mock_config):
+        """Test that lost connection triggers reconnection."""
+        # Setup mock for reconnection
+        mock_transport_cm = AsyncMock()
+        mock_stdio.return_value = mock_transport_cm
+        mock_transport_cm.__aenter__.return_value = (MagicMock(), MagicMock())
 
-    assert mock_conn1.disconnect.called
-    assert mock_conn2.disconnect.called
-    assert len(manager._connections) == 0
+        mock_session_cm = AsyncMock()
+        mock_session_cls.return_value = mock_session_cm
+        new_session = AsyncMock(spec=ClientSession)
+        mock_session_cm.__aenter__.return_value = new_session
+
+        # Setup connection with a session that will fail ping
+        conn = MCPConnection(name="test", config=mock_config)
+        old_session = AsyncMock(spec=ClientSession)
+        old_session.send_ping = AsyncMock(side_effect=Exception("Connection lost"))
+        conn.session = old_session
+
+        # Connect should detect lost connection and reconnect
+        result = await conn.connect()
+
+        assert result == new_session
+        old_session.send_ping.assert_called_once()
 
 
-@patch("nexus_dev.gateway.connection_manager.MCPConnection")
-@pytest.mark.asyncio
-async def test_connection_manager_invoke_tool(mock_conn_cls, mock_config):
-    """Test invoke_tool uses connection and calls tool."""
-    manager = ConnectionManager()
+class TestMCPConnectionRetry:
+    """Tests for connection retry logic."""
 
-    mock_session = AsyncMock()
-    mock_session.call_tool = AsyncMock(return_value="result")
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @patch("nexus_dev.gateway.connection_manager.ClientSession")
+    @pytest.mark.asyncio
+    async def test_retry_success_on_second_attempt(self, mock_session_cls, mock_stdio, mock_config):
+        """Test successful connection after initial failure."""
+        # First attempt fails, second succeeds
+        mock_transport_cm = AsyncMock()
+        mock_transport_cm.__aenter__.side_effect = [
+            Exception("First attempt failed"),
+            (MagicMock(), MagicMock()),
+        ]
+        mock_stdio.return_value = mock_transport_cm
 
-    mock_conn_instance = AsyncMock()
-    mock_conn_instance.connect.return_value = mock_session
-    mock_conn_cls.return_value = mock_conn_instance
+        mock_session_cm = AsyncMock()
+        mock_session_cls.return_value = mock_session_cm
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session_cm.__aenter__.return_value = mock_session
 
-    result = await manager.invoke_tool("test", mock_config, "my_tool", {"arg": "value"})
+        conn = MCPConnection(name="test", config=mock_config, retry_delay=0.01)
 
-    assert result == "result"
-    mock_session.call_tool.assert_called_once_with("my_tool", {"arg": "value"})
+        session = await conn.connect()
+
+        assert session == mock_session
+        assert mock_transport_cm.__aenter__.call_count == 2
+
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded_raises_error(self, mock_stdio, mock_config):
+        """Test MCPConnectionError after max retries."""
+        mock_transport_cm = AsyncMock()
+        mock_transport_cm.__aenter__.side_effect = Exception("Connection failed")
+        mock_stdio.return_value = mock_transport_cm
+
+        conn = MCPConnection(name="test", config=mock_config, max_retries=3, retry_delay=0.01)
+
+        with pytest.raises(MCPConnectionError) as exc_info:
+            await conn.connect()
+
+        assert "Failed to connect to test after 3 attempts" in str(exc_info.value)
+        assert mock_transport_cm.__aenter__.call_count == 3
+
+    @patch("nexus_dev.gateway.connection_manager.asyncio.sleep")
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @pytest.mark.asyncio
+    async def test_exponential_backoff(self, mock_stdio, mock_sleep, mock_config):
+        """Test that retry delays use exponential backoff."""
+        mock_transport_cm = AsyncMock()
+        mock_transport_cm.__aenter__.side_effect = Exception("Connection failed")
+        mock_stdio.return_value = mock_transport_cm
+        mock_sleep.return_value = None
+
+        conn = MCPConnection(name="test", config=mock_config, max_retries=4, retry_delay=1.0)
+
+        with pytest.raises(MCPConnectionError):
+            await conn.connect()
+
+        # Check exponential backoff: 1.0, 2.0, 4.0 (3 sleeps for 4 attempts)
+        assert mock_sleep.call_count == 3
+        calls = [call.args[0] for call in mock_sleep.call_args_list]
+        assert calls == [1.0, 2.0, 4.0]
+
+
+class TestMCPConnectionTimeout:
+    """Tests for timeout functionality."""
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_timeout_success(self, mock_config):
+        """Test successful tool invocation within timeout."""
+        conn = MCPConnection(name="test", config=mock_config, timeout=5.0)
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.send_ping = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value="result")
+        conn.session = mock_session
+
+        result = await conn.invoke_with_timeout("my_tool", {"arg": "value"})
+
+        assert result == "result"
+        mock_session.call_tool.assert_called_once_with("my_tool", {"arg": "value"})
+
+    @pytest.mark.asyncio
+    async def test_invoke_with_timeout_raises_timeout_error(self, mock_config):
+        """Test MCPTimeoutError when tool exceeds timeout."""
+        conn = MCPConnection(name="test", config=mock_config, timeout=0.01)
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.send_ping = AsyncMock()
+
+        # Simulate a slow tool that times out
+        async def slow_tool(*args, **kwargs):
+            await asyncio.sleep(1.0)
+            return "result"
+
+        mock_session.call_tool = slow_tool
+        conn.session = mock_session
+
+        with pytest.raises(MCPTimeoutError) as exc_info:
+            await conn.invoke_with_timeout("slow_tool", {})
+
+        assert "slow_tool" in str(exc_info.value)
+        assert "timed out" in str(exc_info.value)
+
+
+class TestMCPConnectionLogging:
+    """Tests for logging output."""
+
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @pytest.mark.asyncio
+    async def test_logs_warning_on_retry(self, mock_stdio, mock_config, caplog):
+        """Test warning logs during retry attempts."""
+        mock_transport_cm = AsyncMock()
+        mock_transport_cm.__aenter__.side_effect = Exception("Connection failed")
+        mock_stdio.return_value = mock_transport_cm
+
+        conn = MCPConnection(
+            name="test-server", config=mock_config, max_retries=2, retry_delay=0.01
+        )
+
+        with caplog.at_level(logging.WARNING), pytest.raises(MCPConnectionError):
+            await conn.connect()
+
+        assert "Connection attempt 1/2 to test-server failed" in caplog.text
+        assert "Connection attempt 2/2 to test-server failed" in caplog.text
+
+    @patch("nexus_dev.gateway.connection_manager.stdio_client")
+    @patch("nexus_dev.gateway.connection_manager.ClientSession")
+    @pytest.mark.asyncio
+    async def test_logs_info_on_connect(self, mock_session_cls, mock_stdio, mock_config, caplog):
+        """Test info log on successful connection."""
+        mock_transport_cm = AsyncMock()
+        mock_stdio.return_value = mock_transport_cm
+        mock_transport_cm.__aenter__.return_value = (MagicMock(), MagicMock())
+
+        mock_session_cm = AsyncMock()
+        mock_session_cls.return_value = mock_session_cm
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session_cm.__aenter__.return_value = mock_session
+
+        conn = MCPConnection(name="test-server", config=mock_config)
+
+        with caplog.at_level(logging.INFO):
+            await conn.connect()
+
+        assert "Connected to MCP server: test-server" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_on_lost_connection(self, mock_config, caplog):
+        """Test warning log when connection is lost."""
+        conn = MCPConnection(name="test-server", config=mock_config, max_retries=1)
+        mock_session = AsyncMock(spec=ClientSession)
+        mock_session.send_ping = AsyncMock(side_effect=Exception("Connection lost"))
+        conn.session = mock_session
+
+        with caplog.at_level(logging.WARNING), pytest.raises(MCPConnectionError):
+            await conn.connect()
+
+        assert "Connection to test-server lost, reconnecting" in caplog.text
+
+
+class TestConnectionManager:
+    """Tests for ConnectionManager pooling."""
+
+    @patch("nexus_dev.gateway.connection_manager.MCPConnection")
+    @pytest.mark.asyncio
+    async def test_connection_reuse(self, mock_conn_cls, mock_config):
+        """Test connection reuse."""
+        manager = ConnectionManager()
+        mock_conn_instance = AsyncMock()
+        mock_conn_instance.connect.return_value = AsyncMock(spec=ClientSession)
+        mock_conn_cls.return_value = mock_conn_instance
+
+        # First call - creates new connection
+        s1 = await manager.get_connection("s1", mock_config)
+        assert mock_conn_cls.call_count == 1
+
+        # Second call - reuses connection
+        s2 = await manager.get_connection("s1", mock_config)
+        assert mock_conn_cls.call_count == 1
+        assert s1 == s2
+
+    @pytest.mark.asyncio
+    async def test_disconnect_all(self, mock_config):
+        """Test disconnecting all servers."""
+        manager = ConnectionManager()
+
+        mock_conn1 = AsyncMock()
+        mock_conn2 = AsyncMock()
+
+        manager._connections["c1"] = mock_conn1
+        manager._connections["c2"] = mock_conn2
+
+        await manager.disconnect_all()
+
+        assert mock_conn1.disconnect.called
+        assert mock_conn2.disconnect.called
+        assert len(manager._connections) == 0
+
+    @patch("nexus_dev.gateway.connection_manager.MCPConnection")
+    @pytest.mark.asyncio
+    async def test_invoke_tool(self, mock_conn_cls, mock_config):
+        """Test invoke_tool uses connection and calls tool with timeout."""
+        manager = ConnectionManager()
+
+        mock_conn_instance = AsyncMock()
+        mock_conn_instance.invoke_with_timeout = AsyncMock(return_value="result")
+        mock_conn_cls.return_value = mock_conn_instance
+
+        result = await manager.invoke_tool("test", mock_config, "my_tool", {"arg": "value"})
+
+        assert result == "result"
+        mock_conn_instance.invoke_with_timeout.assert_called_once_with("my_tool", {"arg": "value"})
+
+
+class TestExceptions:
+    """Tests for custom exceptions."""
+
+    def test_mcp_connection_error(self):
+        """Test MCPConnectionError can be raised and caught."""
+        with pytest.raises(MCPConnectionError) as exc_info:
+            raise MCPConnectionError("Connection failed")
+
+        assert "Connection failed" in str(exc_info.value)
+
+    def test_mcp_timeout_error(self):
+        """Test MCPTimeoutError can be raised and caught."""
+        with pytest.raises(MCPTimeoutError) as exc_info:
+            raise MCPTimeoutError("Tool timed out")
+
+        assert "Tool timed out" in str(exc_info.value)
+
+    def test_exceptions_are_distinct(self):
+        """Test that exceptions are distinct types."""
+        assert MCPConnectionError != MCPTimeoutError
+        assert not issubclass(MCPConnectionError, MCPTimeoutError)
+        assert not issubclass(MCPTimeoutError, MCPConnectionError)


### PR DESCRIPTION
## Summary

This PR implements error handling and automatic reconnection logic for MCP backend connections as specified in Issue #20.

## Changes

### New Features

| Feature | Description |
|---------|-------------|
| **Auto-reconnection** | Health check with `send_ping()` on existing sessions, automatic cleanup and reconnection if lost |
| **Retry with exponential backoff** | Configurable retries (default: 3) with delays: 1s → 2s → 4s |
| **Timeout protection** | Configurable timeout (default: 30s) for tool invocations |
| **Custom exceptions** | `MCPConnectionError` and `MCPTimeoutError` for clear error handling |
| **Proper logging** | Info, warning, and error level logs throughout connection lifecycle |

### Modified Files

| File | Changes |
|------|---------|
| `src/nexus_dev/gateway/connection_manager.py` | Complete rewrite with retry logic, timeout support, custom exceptions, and logging |
| `src/nexus_dev/gateway/__init__.py` | Export new `MCPConnectionError` and `MCPTimeoutError` exceptions |
| `tests/unit/test_connection_manager.py` | Comprehensive tests (17 test cases) for all new functionality |

### Implementation Details

#### Connection Health Check
```python
if self.session is not None:
    try:
        await self.session.send_ping()
        return self.session
    except Exception:
        logger.warning("Connection to %s lost, reconnecting...", self.name)
        await self._cleanup()
```

#### Retry with Exponential Backoff
```python
for attempt in range(self.max_retries):
    try:
        return await self._do_connect()
    except Exception as e:
        if attempt < self.max_retries - 1:
            delay = self.retry_delay * (2**attempt)  # 1s, 2s, 4s
            await asyncio.sleep(delay)
```

#### Timeout Protection
```python
async def invoke_with_timeout(self, tool: str, arguments: dict[str, Any]) -> Any:
    session = await self.connect()
    try:
        return await asyncio.wait_for(
            session.call_tool(tool, arguments),
            timeout=self.timeout,
        )
    except TimeoutError as e:
        raise MCPTimeoutError(f"Tool '{tool}' timed out after {self.timeout}s") from e
```

## Testing

### New Test Cases (17 tests)

- **Connection Lifecycle**: Basic connect/disconnect flow
- **Ping Health Check**: 
  - Healthy session reuse
  - Lost connection triggers reconnection
- **Retry Logic**:
  - Success on second attempt
  - Max retries exceeded raises `MCPConnectionError`
  - Exponential backoff timing verification
- **Timeout**:
  - Successful invocation within timeout
  - Timeout raises `MCPTimeoutError`
- **Logging Output**:
  - Warning logs on retry attempts
  - Info logs on successful connection
  - Warning logs on lost connection
- **Connection Manager**:
  - Connection reuse/pooling
  - Disconnect all servers
  - Invoke tool with timeout

### Verification

```bash
$ make check
Running linter... All checks passed! ✓
Checking code formatting... 37 files already formatted ✓
Running type checker... Success: no issues found in 16 source files ✓

$ make test
306 passed in 1.46s ✓
```

## Acceptance Criteria Checklist

- [x] Auto-reconnection on connection loss
- [x] Retry with exponential backoff
- [x] Configurable max retries
- [x] Timeout for tool invocation
- [x] Proper logging
- [x] Tests for error scenarios

## Dependencies

- Depends on: #16 (MCP connection manager with pooling) ✅ Already implemented

Closes #20