### PR TITLE
feat: Add timeout configuration for MCP gateway

### DIFF
--- a/src/nexus_dev/schemas/mcp_config_schema.json
+++ b/src/nexus_dev/schemas/mcp_config_schema.json
@@ -35,6 +35,18 @@
                             "type": "string"
                         },
                         "default": {}
+                    },
+                    "timeout": {
+                        "type": "number",
+                        "description": "Tool execution timeout in seconds",
+                        "default": 30,
+                        "minimum": 1
+                    },
+                    "connect_timeout": {
+                        "type": "number",
+                        "description": "Connection timeout in seconds",
+                        "default": 10,
+                        "minimum": 1
                     }
                 },
                 "required": [
@@ -52,6 +64,24 @@
                 }
             },
             "default": {}
+        },
+        "gateway": {
+            "type": "object",
+            "description": "Global gateway settings",
+            "properties": {
+                "default_timeout": {
+                    "type": "number",
+                    "description": "Default tool execution timeout",
+                    "default": 30,
+                    "minimum": 1
+                },
+                "max_concurrent_connections": {
+                    "type": "integer",
+                    "description": "Maximum concurrent connections to backend servers",
+                    "default": 5,
+                    "minimum": 1
+                }
+            }
         },
         "active_profile": {
             "type": "string",


### PR DESCRIPTION
## Overview
Closes #21. This PR implements timeout configuration for MCP gateway connections, adding both per-server settings and global gateway defaults.

## Changes
- Updated `mcp_config_schema.json` to include `timeout`, `connect_timeout`, and `gateway` settings.
- Updated `MCPServerConfig` and `MCPConfig` data models.
- Updated `ConnectionManager` to respect configured timeouts.
- Added comprehensive unit tests for configuration parsing and connection timeouts.

## Verification
- Run `make check` - Passed
- Run `make test` - Passed
