### PR TITLE
Add Nexus-Dev demo and code_snippet param to record_lesson

### DIFF
--- a/nexus_dev_demo.md
+++ b/nexus_dev_demo.md
@@ -1,0 +1,33 @@
+# Nexus-Dev Demo: Counting Closed GitHub Issues
+
+This document details the steps taken by the AI agent to count closed issues in the `mmornati/nexus-dev` repository using the Nexus-Dev MCP gateway.
+
+## Step 1: Verification of Available Tools
+First, the agent verified that the GitHub MCP server was active and available through the Nexus-Dev gateway.
+
+**Tool:** `list_servers`
+**Reasoning:** Before attempting to use any GitHub tools, it is necessary to confirm that the GitHub MCP server is correctly connected and recognized by the Nexus-Dev system.
+**Result:** Verified `github` server is active.
+
+## Step 2: Tool Discovery
+The agent searched for the appropriate tool to list GitHub issues.
+
+**Tool:** `search_tools(query="list issues", server="github")`
+**Reasoning:** The agent needed to find the specific function signature for listing issues to ensure the correct arguments (like `state="CLOSED"`) were provided.
+**Result:** Found `github.list_issues` with the following relevant parameters:
+- `owner` (string): Repository owner
+- `repo` (string): Repository name
+- `state` (string): Filter by state (`OPEN`, `CLOSED`)
+
+## Step 3: Execution
+The agent invoked the discovered tool to retrieve the data.
+
+**Tool:** `invoke_tool(server="github", tool="list_issues", arguments={"owner": "mmornati", "repo": "nexus-dev", "state": "CLOSED"})`
+**Reasoning:** With the tool and parameters identified, the agent executed the command to fetch the actual data.
+**Result:** The tool returned a JSON response containing a list of issues.
+
+## Step 4: Analysis
+The agent processed the JSON output to count the number of items in the returned list.
+
+**Reasoning:** The tool returns the raw data (lists of issues). The agent's role is to interpret this data to answer the user's specific question ("Count the closed issues").
+**Final Answer:** There are **23** closed issues in the `mmornati/nexus-dev` repository.

--- a/src/nexus_dev/server.py
+++ b/src/nexus_dev/server.py
@@ -775,6 +775,7 @@ async def record_lesson(
     problem: str,
     solution: str,
     context: str | None = None,
+    code_snippet: str | None = None,
     project_id: str | None = None,
 ) -> str:
     """Record a learned lesson from debugging or problem-solving.
@@ -789,6 +790,8 @@ async def record_lesson(
         solution: How the problem was resolved.
                   Example: "Added null check before calling get_user() and return early if None"
         context: Optional additional context like file path, library, error message.
+        code_snippet: Optional code snippet that demonstrates the problem or solution.
+                      This is highly recommended to provide concrete examples.
         project_id: Optional project identifier. Uses current project if not specified.
 
     Returns:
@@ -816,6 +819,9 @@ async def record_lesson(
 
     if context:
         lesson_parts.extend(["", "## Context", context])
+
+    if code_snippet:
+        lesson_parts.extend(["", "## Code", "```", code_snippet, "```"])
 
     lesson_text = "\n".join(lesson_parts)
 


### PR DESCRIPTION
This pull request introduces documentation and API improvements to the Nexus-Dev project, focusing on better recording of lessons and providing a concrete example of agent usage. The most important changes are grouped below:

### Documentation and Example

* Added a new file `nexus_dev_demo.md` that documents a step-by-step demo of how the AI agent counts closed GitHub issues in the `mmornati/nexus-dev` repository using the Nexus-Dev MCP gateway. This includes tool verification, discovery, execution, and analysis, culminating in a concrete answer.

### API Improvements for Lesson Recording

* Updated the `record_lesson` function in `src/nexus_dev/server.py` to accept an optional `code_snippet` parameter, allowing users to attach code examples to lessons for better clarity.
* Improved the docstring for `record_lesson` to document the new `code_snippet` parameter and recommend its usage for more concrete examples.
* Enhanced lesson formatting in `record_lesson` to include a "## Code" section with the provided code snippet, making lessons more informative and actionable.