### PR TITLE
[Phase 0] Add KùzuDB dependency and create HybridDatabase wrapper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "tree-sitter-language-pack>=0.7.0", # Pre-built parsers (100+ languages)
     "jsonschema>=4.18.0",               # JSON schema validation
     "pandas>=2.0.0",                    # DataFrame support for LanceDB
+    "kuzu>=0.7.0",                      # Graph database
 ]
 
 [project.optional-dependencies]
@@ -118,6 +119,8 @@ module = [
     "cohere.*",
     "boto3",
     "boto3.*",
+    "kuzu",
+    "kuzu.*",
 ]
 ignore_missing_imports = true
 

--- a/src/nexus_dev/config.py
+++ b/src/nexus_dev/config.py
@@ -65,6 +65,7 @@ class NexusConfig:
     docs_folders: list[str] = field(
         default_factory=lambda: ["docs/", "documentation/", "README.md"]
     )
+    enable_hybrid_db: bool = False  # Feature flag for hybrid database (KV + Vector + Graph)
 
     @classmethod
     def create_new(
@@ -164,6 +165,7 @@ class NexusConfig:
                 ],
             ),
             docs_folders=data.get("docs_folders", ["docs/", "documentation/", "README.md"]),
+            enable_hybrid_db=data.get("enable_hybrid_db", False),
         )
 
     @classmethod
@@ -208,6 +210,7 @@ class NexusConfig:
             "include_patterns": self.include_patterns,
             "exclude_patterns": self.exclude_patterns,
             "docs_folders": self.docs_folders,
+            "enable_hybrid_db": self.enable_hybrid_db,
         }
 
         with open(path, "w", encoding="utf-8") as f:

--- a/src/nexus_dev/hybrid_db.py
+++ b/src/nexus_dev/hybrid_db.py
@@ -1,0 +1,161 @@
+"""Hybrid database manager coordinating KV, Vector, and Graph stores."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import kuzu
+
+    from .config import NexusConfig
+    from .database import NexusDatabase
+
+
+class HybridDatabase:
+    """Coordinates SQLite (KV), LanceDB (Vector), and KùzuDB (Graph).
+
+    This class provides a unified interface to three complementary database systems:
+    - SQLite (KV): Fast exact lookups for session state and chat history
+    - LanceDB (Vector): Semantic search via embeddings (existing)
+    - KùzuDB (Graph): Code relationships and dependency graphs
+
+    Attributes:
+        config: Nexus-Dev configuration
+    """
+
+    def __init__(self, config: NexusConfig) -> None:
+        """Initialize hybrid database manager.
+
+        Args:
+            config: Nexus-Dev configuration
+        """
+        self.config = config
+        self._kv: sqlite3.Connection | None = None
+        self._vector: NexusDatabase | None = None
+        self._graph_db: kuzu.Database | None = None
+        self._graph_conn: kuzu.Connection | None = None
+
+    def connect(self) -> None:
+        """Initialize all database connections.
+
+        Creates database directories and initializes schemas if needed.
+        Only connects to enabled databases.
+        """
+        if not self.config.enable_hybrid_db:
+            return
+
+        db_path = self.config.get_db_path()
+
+        # KV Store (SQLite)
+        kv_path = db_path / "state.db"
+        kv_path.parent.mkdir(parents=True, exist_ok=True)
+        self._kv = sqlite3.connect(str(kv_path))
+        self._kv.row_factory = sqlite3.Row
+        self._init_kv_schema()
+
+        # Graph Store (KùzuDB)
+        # KùzuDB creates the directory automatically - don't mkdir first
+        graph_path = db_path / "graph_db"
+
+        # Lazy import kuzu to avoid dependency when hybrid mode is disabled
+        import kuzu
+
+        self._graph_db = kuzu.Database(str(graph_path))
+        self._graph_conn = kuzu.Connection(self._graph_db)
+        self._init_graph_schema()
+
+    def _init_kv_schema(self) -> None:
+        """Create KV store tables if not exist.
+
+        Note: Full schema implementation will be added in Phase 1 (#57).
+        For now, just creates the basic structure.
+        """
+        if self._kv is None:
+            return
+
+        # Placeholder - will be implemented in #57
+        self._kv.executescript("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+        self._kv.commit()
+
+    def _init_graph_schema(self) -> None:
+        """Create graph schema if not exist.
+
+        Note: Full schema implementation will be added in Phase 2 (#59).
+        For now, just verifies connection works.
+        """
+        # Placeholder - will be implemented in #59
+        pass
+
+    @property
+    def kv(self) -> sqlite3.Connection:
+        """Get KV store connection.
+
+        Returns:
+            SQLite connection
+
+        Raises:
+            RuntimeError: If hybrid mode is not enabled
+        """
+        if not self.config.enable_hybrid_db:
+            raise RuntimeError(
+                "Hybrid database is not enabled. Set enable_hybrid_db=True in config."
+            )
+
+        if self._kv is None:
+            self.connect()
+
+        if self._kv is None:
+            raise RuntimeError("Failed to initialize KV store")
+
+        return self._kv
+
+    @property
+    def graph(self) -> Any:  # kuzu.Connection
+        """Get graph connection.
+
+        Returns:
+            KùzuDB connection
+
+        Raises:
+            RuntimeError: If hybrid mode is not enabled
+        """
+        if not self.config.enable_hybrid_db:
+            raise RuntimeError(
+                "Hybrid database is not enabled. Set enable_hybrid_db=True in config."
+            )
+
+        if self._graph_conn is None:
+            self.connect()
+
+        if self._graph_conn is None:
+            raise RuntimeError("Failed to initialize graph store")
+
+        return self._graph_conn
+
+    def close(self) -> None:
+        """Close all database connections."""
+        if self._kv:
+            self._kv.close()
+            self._kv = None
+
+        if self._graph_conn:
+            self._graph_conn = None
+
+        if self._graph_db:
+            self._graph_db = None
+
+    def __enter__(self) -> HybridDatabase:
+        """Context manager entry."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit."""
+        self.close()

--- a/tests/test_hybrid_db.py
+++ b/tests/test_hybrid_db.py
@@ -1,0 +1,173 @@
+"""Tests for hybrid database module."""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus_dev.config import NexusConfig
+from nexus_dev.hybrid_db import HybridDatabase
+
+
+def test_hybrid_database_disabled_by_default(tmp_path: Path) -> None:
+    """Test that hybrid database is disabled by default."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+
+    db = HybridDatabase(config)
+
+    # Should not connect when disabled
+    db.connect()
+    assert db._kv is None
+    assert db._graph_conn is None
+
+
+def test_hybrid_database_requires_flag(tmp_path: Path) -> None:
+    """Test that accessing databases without enable flag raises error."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = False
+
+    db = HybridDatabase(config)
+
+    with pytest.raises(RuntimeError, match="Hybrid database is not enabled"):
+        _ = db.kv
+
+    with pytest.raises(RuntimeError, match="Hybrid database is not enabled"):
+        _ = db.graph
+
+
+def test_hybrid_database_initialization(tmp_path: Path) -> None:
+    """Test hybrid database initializes all components when enabled."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    db = HybridDatabase(config)
+    db.connect()
+
+    try:
+        # KV store should be initialized
+        assert db._kv is not None
+        assert isinstance(db._kv, sqlite3.Connection)
+
+        # Graph store should be initialized
+        assert db._graph_db is not None
+        assert db._graph_conn is not None
+
+        # KV schema should be created
+        cursor = db._kv.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'"
+        )
+        assert cursor.fetchone() is not None
+
+    finally:
+        db.close()
+
+
+def test_kv_property_lazy_initialization(tmp_path: Path) -> None:
+    """Test KV property initializes connection on first access."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    db = HybridDatabase(config)
+
+    # Should initialize on property access
+    kv = db.kv
+    assert kv is not None
+    assert isinstance(kv, sqlite3.Connection)
+
+    db.close()
+
+
+def test_graph_property_lazy_initialization(tmp_path: Path) -> None:
+    """Test graph property initializes connection on first access."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    db = HybridDatabase(config)
+
+    # Should initialize on property access
+    graph = db.graph
+    assert graph is not None
+
+    db.close()
+
+
+def test_context_manager(tmp_path: Path) -> None:
+    """Test hybrid database works as context manager."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    with HybridDatabase(config) as db:
+        # Should be connected
+        assert db._kv is not None
+        kv = db.kv
+        assert kv is not None
+
+    # Should be closed after context
+    # Note: SQLite connection might still work, but that's ok
+
+
+def test_database_directories_created(tmp_path: Path) -> None:
+    """Test that database directories are created on initialization."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    db = HybridDatabase(config)
+    db.connect()
+
+    try:
+        db_path = Path(tmp_path / "db")
+        assert db_path.exists()
+        assert (db_path / "state.db").exists()
+        # KùzuDB creates its own subdirectories (.tmp, etc.)
+        assert db_path.is_dir()
+    finally:
+        db.close()
+
+
+def test_close_idempotent(tmp_path: Path) -> None:
+    """Test that close() can be called multiple times safely."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    db = HybridDatabase(config)
+    db.connect()
+
+    # Should not raise on multiple closes
+    db.close()
+    db.close()
+    db.close()
+
+
+def test_config_persistence(tmp_path: Path) -> None:
+    """Test that enable_hybrid_db persists in config file."""
+    config_path = tmp_path / "nexus_config.json"
+
+    # Create and save config with hybrid enabled
+    config = NexusConfig.create_new("test-project")
+    config.enable_hybrid_db = True
+    config.save(config_path)
+
+    # Load config and verify flag persists
+    loaded_config = NexusConfig.load(config_path)
+    assert loaded_config.enable_hybrid_db is True
+
+
+def test_config_defaults_to_false(tmp_path: Path) -> None:
+    """Test that enable_hybrid_db defaults to False in loaded config."""
+    config_path = tmp_path / "nexus_config.json"
+
+    # Create and save config without hybrid flag
+    config = NexusConfig.create_new("test-project")
+    config.save(config_path)
+
+    # Load config and verify flag defaults to False
+    loaded_config = NexusConfig.load(config_path)
+    assert loaded_config.enable_hybrid_db is False


### PR DESCRIPTION
## Overview

Implements **Issue #56** - Hybrid Database Foundation (Phase 0)

This PR adds the foundational infrastructure for the hybrid database architecture (ADR-003), which will coordinate **three complementary databases**:
- **SQLite (KV)**: Fast exact lookups for session state and chat history  
- **LanceDB (Vector)**: Semantic search via embeddings (existing)
- **KùzuDB (Graph)**: Code relationships and dependency graphs

## Changes

### Dependencies
- ✅ Added `kuzu>=0.7.0` to `pyproject.toml`
- ✅ Added `kuzu` to mypy ignore list (no type stubs available)

### Configuration
- ✅ Added `enable_hybrid_db: bool = False` feature flag to `NexusConfig`
  - Defaults to **disabled** for backward compatibility
  - Persists in `nexus_config.json`

### New Module: `hybrid_db.py`

Created `HybridDatabase` wrapper class:
- **Lazy initialization**: Only connects when `enable_hybrid_db=True`
- **Context manager support**: `with HybridDatabase(config) as db:`
- **Properties**:
  - `db.kv` → SQLite connection
  - `db.graph` → KùzuDB connection
  - Both raise helpful errors when hybrid mode disabled

### Database Locations
```
~/.nexus-dev/db/
├── state.db           # SQLite KV store
└── graph_db/          # KùzuDB graph database
    ├── .tmp/
    └── catalog/
```

### Placeholder Schemas

Minimal schemas created for Phase 0:
- **KV**: Basic `sessions` table
- **Graph**: No tables yet (Phase 2 #59)

Full schemas will be implemented in:
- Phase 1 (#57) - KV tables for chat history, config cache
- Phase 2 (#59) - Graph schema for code entities and relationships

## Testing

### Test Coverage
- ✅ **10 tests added** in `tests/test_hybrid_db.py`
- ✅ **100% pass rate**
- Coverage:
  - Disabled by default behavior
  - Feature flag enforcement
  - Lazy initialization
  - Context manager
  - Config persistence
  - Multiple close() calls (idempotent)

### Validation
```bash
# Tests
pytest tests/test_hybrid_db.py -v
# 10 passed in 0.20s

# Linting
ruff check src/nexus_dev/hybrid_db.py
# All checks passed!

# Type checking  
mypy src/nexus_dev/hybrid_db.py src/nexus_dev/config.py
# Success: no issues found
```

## Breaking Changes

**None** - The hybrid database is opt-in via `enable_hybrid_db` flag.

## Migration Guide

To enable hybrid database:

```json
// nexus_config.json
{
  "enable_hybrid_db": true
}
```

Note: Enabling this in Phase 0 only creates empty databases. Full functionality comes in Phase 1-4.

## Next Steps

- [ ] Phase 1 (#57, #58) - SQLite KV Store implementation
- [ ] Phase 2 (#59, #60, #61) - KùzuDB Graph implementation  
- [ ] Phase 3 (#62) - Entity extraction
- [ ] Phase 4 (#63) - Hybrid query routing

## Related

- Epic: #67 (Hybrid Database Architecture)
- ADR: [ADR-003](../adrs/adr-003-hybrid-database-architecture.md)
- Closes: #56

## Checklist

- [x] Code follows project style guide (ruff passes)
- [x] Type annotations added (mypy passes)
- [x] Tests added and passing (10/10)
- [x] Feature flag added for opt-in
- [x] No breaking changes
- [x] Documentation comments added