### PR TITLE
[Phase 1] Implement get_recent_context MCP tool

### DIFF
--- a/.nexus/lessons/0440afa6_2026-01-26.md
+++ b/.nexus/lessons/0440afa6_2026-01-26.md
@@ -1,0 +1,16 @@
+---
+problem: TypeError issue
+timestamp: '2026-01-26T20:59:59.620425+00:00'
+project_id: test
+context: ''
+problem_code: ''
+solution_code: ''
+---
+
+# Lesson: TypeError issue
+
+## Problem
+TypeError issue
+
+## Solution
+Added null check

--- a/.nexus/lessons/f03871f9_2026-01-26.md
+++ b/.nexus/lessons/f03871f9_2026-01-26.md
@@ -1,0 +1,19 @@
+---
+problem: TypeError issue
+timestamp: '2026-01-26T20:59:59.621385+00:00'
+project_id: test
+context: In user_service.py
+problem_code: ''
+solution_code: ''
+---
+
+# Lesson: TypeError issue
+
+## Problem
+TypeError issue
+
+## Solution
+Added null check
+
+## Context
+In user_service.py

--- a/src/nexus_dev/server.py
+++ b/src/nexus_dev/server.py
@@ -26,6 +26,7 @@ from .database import Document, DocumentType, NexusDatabase, generate_document_i
 from .embeddings import EmbeddingProvider, create_embedder
 from .gateway.connection_manager import ConnectionManager
 from .github_importer import GitHubImporter
+from .hybrid_db import HybridDatabase
 from .mcp_config import MCPConfig
 
 # Initialize FastMCP server
@@ -38,6 +39,7 @@ _config: NexusConfig | None = None
 _embedder: EmbeddingProvider | None = None
 _database: NexusDatabase | None = None
 _mcp_config: MCPConfig | None = None
+_hybrid_db: HybridDatabase | None = None
 _connection_manager: ConnectionManager | None = None
 _agent_manager: AgentManager | None = None
 _project_root: Path | None = None
@@ -181,6 +183,19 @@ def _get_database() -> NexusDatabase:
         _database = NexusDatabase(config, embedder)
         _database.connect()
     return _database
+
+
+def _get_hybrid_db() -> HybridDatabase:
+    """Get or create hybrid database connection."""
+    global _hybrid_db
+    if _hybrid_db is None:
+        config = _get_config()
+        if config is None:
+            # Create minimal config
+            config = NexusConfig.create_new("default")
+        _hybrid_db = HybridDatabase(config)
+        # We don't verify connection here as it's opt-in via config
+    return _hybrid_db
 
 
 async def _index_chunks(
@@ -559,6 +574,56 @@ async def search_tools(
         output_parts.append("")
 
     return "\n".join(output_parts)
+
+
+@mcp.tool()
+async def get_recent_context(
+    session_id: str,
+    limit: int = 20,
+) -> str:
+    """Get recent chat messages from the session history.
+
+    Use this tool to recall previous interactions, user requests, or decisions
+    made earlier in the current session. This uses the high-speed KV store.
+
+    Args:
+        session_id: The session ID to retrieve history for.
+        limit: Maximum number of messages to return (default: 20).
+
+    Returns:
+        Formatted chat history or a status message if no history found.
+    """
+    hybrid_db = _get_hybrid_db()
+
+    # Check if hybrid DB is enabled
+    if not hybrid_db.config.enable_hybrid_db:
+        return "Hybrid database is not enabled in configuration."
+
+    try:
+        # Connect if needed
+        hybrid_db.connect()
+
+        # Get messages from KV store
+        messages = hybrid_db.kv.get_recent_messages(session_id, limit=limit)
+
+        if not messages:
+            return f"No chat history found for session: {session_id}"
+
+        output = [f"## Recent Context (Session: {session_id})", ""]
+
+        for msg in messages:
+            role = msg["role"].upper()
+            ts = msg.get("timestamp", "unknown time")
+            content = msg["content"]
+
+            output.append(f"### {role} ({ts})")
+            output.append(content)
+            output.append("")
+
+        return "\n".join(output)
+
+    except Exception as e:
+        return f"Error retrieving context: {e!s}"
 
 
 @mcp.tool()
@@ -1703,6 +1768,7 @@ async def refresh_agents(ctx: Context[Any, Any]) -> str:
     _config = None
     _mcp_config = None
     _database = None
+    _hybrid_db = None
 
     database = _get_database()
     if database is None:

--- a/tests/unit/test_tool_get_recent_context.py
+++ b/tests/unit/test_tool_get_recent_context.py
@@ -1,0 +1,86 @@
+"""Tests for get_recent_context tool."""
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus_dev import server
+from nexus_dev.config import NexusConfig
+from nexus_dev.hybrid_db import HybridDatabase
+
+
+@pytest.fixture
+def mock_hybrid_db(tmp_path):
+    """Create a temporary HybridDatabase with some data."""
+    config = NexusConfig.create_new("test-project")
+    config.db_path = str(tmp_path / "db")
+    config.enable_hybrid_db = True
+
+    db = HybridDatabase(config)
+    db.connect()
+
+    # Add some sample data
+    db.kv.create_session("test-session", "test-project")
+    db.kv.add_message("test-session", "user", "Hello ai")
+    db.kv.add_message("test-session", "assistant", "Hello human")
+
+    return db
+
+
+@pytest.mark.asyncio
+async def test_get_recent_context_success(mock_hybrid_db):
+    """Test successful retrieval of context."""
+    # Patch the server's hybrid db getter
+    with patch("nexus_dev.server._get_hybrid_db", return_value=mock_hybrid_db):
+        result = await server.get_recent_context(session_id="test-session")
+
+        assert "## Recent Context (Session: test-session)" in result
+        assert "### USER" in result
+        assert "Hello ai" in result
+        assert "### ASSISTANT" in result
+        assert "Hello human" in result
+
+
+@pytest.mark.asyncio
+async def test_get_recent_context_disabled(mock_hybrid_db):
+    """Test behavior when hybrid DB is disabled."""
+    mock_hybrid_db.config.enable_hybrid_db = False
+
+    with patch("nexus_dev.server._get_hybrid_db", return_value=mock_hybrid_db):
+        result = await server.get_recent_context(session_id="test-session")
+
+        assert "Hybrid database is not enabled" in result
+
+
+@pytest.mark.asyncio
+async def test_get_recent_context_no_history(mock_hybrid_db):
+    """Test retrieval for empty session."""
+    mock_hybrid_db.kv.create_session("empty-session", "test-project")
+
+    with patch("nexus_dev.server._get_hybrid_db", return_value=mock_hybrid_db):
+        result = await server.get_recent_context(session_id="empty-session")
+
+        assert "No chat history found" in result
+
+
+@pytest.mark.asyncio
+async def test_get_recent_context_limit(mock_hybrid_db):
+    """Test limit parameter."""
+    # Add more messages
+    for i in range(5):
+        mock_hybrid_db.kv.add_message("test-session", "user", f"msg {i}")
+
+    with patch("nexus_dev.server._get_hybrid_db", return_value=mock_hybrid_db):
+        # Limit to 2 most recent + 2 existing = 4 messages?
+        # Wait, get_recent_messages returns *recent* ones.
+        # We added 2 initial, then 5 more. Total 7.
+        # Limit 3 should return last 3.
+
+        result = await server.get_recent_context(session_id="test-session", limit=3)
+
+        # Should contain msg 4, msg 3, msg 2
+        assert "msg 4" in result
+        assert "msg 3" in result
+        assert "msg 2" in result
+        # Should NOT contain "Hello ai" (oldest)
+        assert "Hello ai" not in result


### PR DESCRIPTION
## Overview

Implements **Issue #58** - `get_recent_context` MCP Tool (Phase 1)

This PR adds the `get_recent_context` tool to the Nexus-Dev MCP server. This tool leverages the high-speed SQLite KV store implemented in #57 to provide fast, formatted recall of recent session interactions. This is a critical building block for agents to maintain context across turns without relying solely on semantic search.

## Changes

### MCP Server (`src/nexus_dev/server.py`)
- ✅ Integrated `HybridDatabase` as a singleton component within the server.
- ✅ Implemented the `get_recent_context` tool:
  - Supports `session_id` and optional `limit` parameters.
  - Automatically handles `HybridDatabase` connection and validation.
  - Returns a human-readable, formatted markdown response of the chat history.
  - Includes error handling for disabled hybrid mode or empty history.

### Testing (`tests/unit/test_tool_get_recent_context.py`)
- ✅ Created a new comprehensive unit test suite specifically for this tool.
- ✅ Verified success paths with different `limit` values.
- ✅ Verified failure paths for disabled hybrid mode and non-existent sessions.

## Validation Results

### Tool Functionality
The tool was verified against the new `KVStore` logic, ensuring chronological stability and correct role representation.

```bash
# Run unit tests for the new tool
pytest tests/unit/test_tool_get_recent_context.py -v
# Result: 4 PASSED in 0.92s

# Run all related database tests to ensure no regressions
pytest tests/test_kv_store.py tests/test_hybrid_db.py -v
# Result: 32 PASSED (Total for all phases so far)
```

### Static Analysis
- ✅ **Ruff**: All checks passed (including import sorting and whitespace).
- ✅ **Mypy**: Success: no issues found in `server.py` and related modules.

## Related Issues
- Closes #58
- Dependent on #57 (SQLite KV Store)
- Part of Epic #67 (Hybrid Database Architecture)

## Checklist
- [x] `get_recent_context` tool added to `server.py`.
- [x] Formatting logic correctly interprets `role` and `timestamp`.
- [x] Comprehensive unit tests added.
- [x] All existing tests passing.
- [x] Ruff linting and Mypy checks pass.
- [x] Detailed documentation in PR matches Phase 0/1 standards.