### PR TITLE
🧹 Code Health: Remove unused parameter from JSGraphBuilder

### DIFF
--- a/src/nexus_dev/code_graph_js.py
+++ b/src/nexus_dev/code_graph_js.py
@@ -78,7 +78,7 @@ class JSGraphBuilder:
         for pattern in func_patterns:
             for match in re.finditer(pattern, content):
                 func_name = match.group(1)
-                self._add_function(rel_path, func_name, match.start())
+                self._add_function(rel_path, func_name)
                 stats["functions"] += 1
 
         # Extract classes
@@ -132,7 +132,7 @@ class JSGraphBuilder:
             {"from_path": from_file, "to_path": module_path},
         )
 
-    def _add_function(self, file_path: str, func_name: str, char_pos: int) -> None:
+    def _add_function(self, file_path: str, func_name: str) -> None:
         """Add function node."""
         func_id = f"{file_path}:{func_name}"
 


### PR DESCRIPTION
Removed the unused `char_pos` parameter from `JSGraphBuilder._add_function` in `src/nexus_dev/code_graph_js.py`.

**Why:**
The parameter was identified as unused, cluttering the method signature and potentially causing confusion.

**Verification:**
- Ran existing tests in `tests/test_code_graph_js.py`.
- Verified `ruff` and `mypy` checks passed.
- Confirmed no other files were affected as `_add_function` is internal to `JSGraphBuilder` and not used elsewhere (verified via grep).


---
*PR created automatically by Jules for task [15793906852279908750](https://jules.google.com/task/15793906852279908750) started by @mmornati*