### PR TITLE
Fix undefined variable in Cypher query for JS class extraction

### DIFF
--- a/src/nexus_dev/code_graph_js.py
+++ b/src/nexus_dev/code_graph_js.py
@@ -159,7 +159,7 @@ class JSGraphBuilder:
         self.graph.query(
             """
             MERGE (c:Class {id: $id})
-            SET c.name = $name, f.file_path = $path
+            SET c.name = $name, c.file_path = $path
             """,
             {"id": class_id, "name": class_name, "path": file_path},
         )

--- a/tests/test_code_graph_js.py
+++ b/tests/test_code_graph_js.py
@@ -116,6 +116,16 @@ def test_index_file_classes(builder, mock_graph, tmp_path):
 
     assert stats["classes"] == 3
 
+    # Verify class node creation
+    class_node_call = call(
+        """
+            MERGE (c:Class {id: $id})
+            SET c.name = $name, c.file_path = $path
+            """,
+        {"id": f"{test_file}:UserProfile", "name": "UserProfile", "path": str(test_file)},
+    )
+    assert class_node_call in mock_graph.query.call_args_list
+
     # Verify inheritance relationship
     inheritance_call = call(
         """


### PR DESCRIPTION
Fixed a code health issue where an undefined variable `f` was used in a Cypher query instead of `c` in `src/nexus_dev/code_graph_js.py`. Enhanced the test suite to verify the fix.

---
*PR created automatically by Jules for task [11243900035721629372](https://jules.google.com/task/11243900035721629372) started by @mmornati*