### PR TITLE
fix(gateway): respect gateway summarize settings when no per-server override

### DIFF
--- a/src/nexus_dev/gateway/connection_manager.py
+++ b/src/nexus_dev/gateway/connection_manager.py
@@ -374,10 +374,15 @@ class ConnectionManager:
         return self._cache
 
     def _get_summarize_settings(self, config: MCPServerConfig) -> SummarizeSettings:
-        """Get summarize settings for this server."""
+        """Get summarize settings for this server.
+
+        Priority: per-server config > gateway config > default (disabled).
+        """
         if config.summarize is not None:
             return config.summarize
-        return SummarizeSettings()
+        if self._summarize_settings is not None:
+            return self._summarize_settings
+        return SummarizeSettings(enabled=False)
 
     def _get_max_concurrent(self, config: MCPServerConfig) -> int:
         """Get max concurrent setting for a server (per-server or default)."""

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -585,3 +585,78 @@ class TestMCPConnectionLogging:
 
         assert "[test-server] Queuing invoke_tool: my_tool" in caplog.text
         assert "[test-server] Tool invocation successful: my_tool" in caplog.text
+
+
+class TestConnectionManagerSummarizeSettings:
+    """Tests for summarize settings in ConnectionManager."""
+
+    def test_get_summarize_settings_default_disabled(self):
+        """Test that default summarize settings have enabled=False."""
+        manager = ConnectionManager()
+        config = MCPServerConfig(
+            command="test-server",
+            args=["--test"],
+        )
+
+        settings = manager._get_summarize_settings(config)
+
+        assert settings.enabled is False
+        assert settings.max_list_items == 10
+        assert settings.max_output_chars == 500
+
+    def test_get_summarize_settings_uses_gateway_config(self):
+        """Test that gateway summarize settings are used when no per-server override."""
+        from nexus_dev.mcp_config import SummarizeSettings
+
+        gateway_settings = SummarizeSettings(enabled=False, max_list_items=5, max_output_chars=100)
+        manager = ConnectionManager(summarize_settings=gateway_settings)
+        config = MCPServerConfig(
+            command="test-server",
+            args=["--test"],
+        )
+
+        settings = manager._get_summarize_settings(config)
+
+        assert settings.enabled is False
+        assert settings.max_list_items == 5
+        assert settings.max_output_chars == 100
+
+    def test_get_summarize_settings_per_server_override(self):
+        """Test that per-server summarize settings override gateway settings."""
+        from nexus_dev.mcp_config import SummarizeSettings
+
+        gateway_settings = SummarizeSettings(enabled=False, max_list_items=5, max_output_chars=100)
+        manager = ConnectionManager(summarize_settings=gateway_settings)
+        per_server_settings = SummarizeSettings(
+            enabled=True, max_list_items=20, max_output_chars=1000
+        )
+        config = MCPServerConfig(
+            command="test-server",
+            args=["--test"],
+            summarize=per_server_settings,
+        )
+
+        settings = manager._get_summarize_settings(config)
+
+        assert settings.enabled is True
+        assert settings.max_list_items == 20
+        assert settings.max_output_chars == 1000
+
+    def test_get_summarize_settings_gateway_enabled_per_server_disabled(self):
+        """Test per-server can disable summarize when gateway has it enabled."""
+        from nexus_dev.mcp_config import SummarizeSettings
+
+        gateway_settings = SummarizeSettings(enabled=True)
+        manager = ConnectionManager(summarize_settings=gateway_settings)
+        per_server_settings = SummarizeSettings(enabled=False)
+        config = MCPServerConfig(
+            command="test-server",
+            args=["--test"],
+            summarize=per_server_settings,
+        )
+
+        settings = manager._get_summarize_settings(config)
+
+        assert settings.enabled is False
+        assert settings.max_list_items == 10
+        assert settings.max_output_chars == 500


### PR DESCRIPTION
## Summary

Fixed a bug where the `gateway.summarize.enabled = false` configuration was being ignored when no per-server `summarize` override was specified.

## Problem

When a user configured `gateway.summarize.enabled = false` in their `mcp_config.yaml`:

```yaml
gateway:
  summarize:
    enabled: false
```

Tool outputs were still being summarized (truncated to 500 chars), causing verbose data like Intervals.icu activity analysis to be unnecessarily shortened.

## Root Cause

In `src/nexus_dev/gateway/connection_manager.py`, the `_get_summarize_settings()` method had this logic:

```python
def _get_summarize_settings(self, config: MCPServerConfig) -> SummarizeSettings:
    if config.summarize is not None:
        return config.summarize
    return SummarizeSettings()  # Always enabled=True!
```

When no per-server `summarize` was specified (`config.summarize is None`), it returned `SummarizeSettings()` with default `enabled=True`, completely ignoring the gateway-level configuration stored in `self._summarize_settings`.

## Solution

Updated `_get_summarize_settings()` to respect the priority chain:

1. **Per-server config** (highest priority)
2. **Gateway config** (fallback)
3. **Default: disabled** (if neither configured)

```python
def _get_summarize_settings(self, config: MCPServerConfig) -> SummarizeSettings:
    """Get summarize settings for this server.

    Priority: per-server config > gateway config > default (disabled).
    """
    if config.summarize is not None:
        return config.summarize
    if self._summarize_settings is not None:
        return self._summarize_settings
    return SummarizeSettings(enabled=False)
```

## Changes

| File | Change |
|------|--------|
| `src/nexus_dev/gateway/connection_manager.py` | Fixed `_get_summarize_settings()` to use gateway settings as fallback |
| `tests/unit/test_connection_manager.py` | Added 4 unit tests for summarize settings priority chain |

## Testing

Added unit tests covering:
- Default summarize settings are disabled (`enabled=False`)
- Gateway settings are used when no per-server override exists
- Per-server settings correctly override gateway settings
- Per-server can disable summarize when gateway has it enabled

All tests pass and `make check` succeeds.

## Behavior Change

**Before:** Default summarization was enabled (could cause unexpected truncation)  
**After:** Default summarization is disabled (more privacy-conscious default)

This is a breaking change only for users who:
1. Never configured summarize settings at any level
2. Relied on the implicit summarization behavior

Such users should explicitly set `gateway.summarize.enabled = true` if they want summarization.