### PR TITLE
fix: configure host/port via FastMCP settings for SSE transport

### DIFF
--- a/src/nexus_dev/server.py
+++ b/src/nexus_dev/server.py
@@ -304,12 +304,15 @@ def main() -> None:
 
         # Run server with selected transport
         if args.transport == "sse":
+            # Configure host and port via settings (FastMCP.run() doesn't accept these directly)
+            mcp.settings.host = args.host
+            mcp.settings.port = args.port
             logger.info(
                 "Server initialization complete, running SSE transport on %s:%d",
                 args.host,
                 args.port,
             )
-            mcp.run(transport="sse", host=args.host, port=args.port)  # type: ignore
+            mcp.run(transport="sse")
         else:
             logger.info("Server initialization complete, running stdio transport")
             mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary

Fixes a `TypeError: FastMCP.run() got an unexpected keyword argument 'host'` error when running nexus-dev via Docker with the SSE transport protocol.

## Problem

When running the nexus-dev Docker image with SSE transport (`--transport sse`), the server fails to start with:

```
TypeError: FastMCP.run() got an unexpected keyword argument 'host'
```

This happens because the code was passing `host` and `port` directly to `mcp.run()`:

```python
mcp.run(transport="sse", host=args.host, port=args.port)  # type: ignore
```

## Solution

The FastMCP API requires `host` and `port` to be set via `mcp.settings` before calling `run()`. The fix configures these settings before starting the server:

```python
mcp.settings.host = args.host
mcp.settings.port = args.port
mcp.run(transport="sse")
```

## Files Changed

- `src/nexus_dev/server.py` - Configure host/port via FastMCP settings before running with SSE transport

## Testing

- All lint, format, and type checks pass
- The fix maintains backward compatibility with existing deployments